### PR TITLE
⬆️ Update Ansible requirements

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -13,7 +13,7 @@ collections:
   - name: community.docker
     version: 4.7.0
   - name: community.general
-    version: 11.1.2
+    version: 11.2.1
   - name: community.mysql
     version: 3.15.0
   - name: debops.debops


### PR DESCRIPTION
🚀 Updated Ansible collection versions in requirements.yml

Rolled up to 11.2.1 for that extra bit of sparkle and efficiency.