### PR TITLE
📚️ Update Ansible role docs

### DIFF
--- a/roles/postfix/README.md
+++ b/roles/postfix/README.md
@@ -25,20 +25,28 @@ Role to configure Postfix.
 
 ```YAML
 postfix_static_settings:
+  alias_database:
   append_dot_mydomain:
   biff:
   body_checks: pcre:/etc/postfix/checks/body_checks.pcre
   bounce_queue_lifetime: 3d
-  default_transport:
+  compatibility_level: '3.6'
+  delay_warning_time: '0'
   header_checks: pcre:/etc/postfix/checks/header_checks.pcre
   header_size_limit: '4096000'
-  maximal_queue_lifetime: 5d
+  inet_interfaces:
+  inet_protocols:
+  maximal_queue_lifetime: 30d
   message_size_limit: '52428800'
   mime_header_checks: pcre:/etc/postfix/checks/mime_header_checks.pcre
+  myhostname: '{{ hostname }}'
+  mynetworks: 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
+  myorigin: $myhostname
   readme_directory:
   recipient_canonical_maps: pcre:/etc/postfix/recipient-canonical-maps.pcre
-  recipient_delimiter: '-'
-  relayhost: '[email-smtp.us-east-1.amazonaws.com]:587'
+  recipient_delimiter: +-
+  relayhost:
+  smtp_bind_address6:
   smtp_sasl_auth_enable: yes
   smtp_sasl_password_maps: hash:/etc/postfix/sasl/sasl_passwd
   smtp_sasl_security_options: noanonymous
@@ -47,8 +55,13 @@ postfix_static_settings:
   smtp_tls_note_starttls_offer: yes
   smtp_tls_security_level: encrypt
   smtp_use_tls: yes
+  smtpd_banner: $myhostname ESMTP
+  smtpd_relay_restrictions:
+    permit_mynetworks,permit_sasl_authenticated,reject_unauth_destination
   smtpd_sasl_auth_enable: yes
+  smtpd_tls_ciphers:
   smtputf8_enable: yes
+  tls_preempt_cipherlist:
   transport_maps:
 ```
 

--- a/roles/postfix/tasks/main.yml
+++ b/roles/postfix/tasks/main.yml
@@ -125,11 +125,27 @@
   changed_when: true
   notify: Restart Postfix
 
-- name: Remove sendgrid service from master.cf
+- name: Remove old SES transport main line without marker
   ansible.builtin.lineinfile:
     path: /etc/postfix/master.cf
-    regexp: '^sendgrid\b'
     state: absent
+    regexp: '^ses\s+unix\s+-\s+n\s+n\s+-\s+-\s+pipe$'
+
+- name: Remove old SES transport continuation line without marker
+  ansible.builtin.lineinfile:
+    path: /etc/postfix/master.cf
+    state: absent
+    regexp: '^\s*flags=Rq user=ses argv=/usr/local/bin/ses_wrapper.sh \${recipient}$'
+
+- name: Configure SES transport in Postfix master.cf
+  ansible.builtin.blockinfile:
+    path: /etc/postfix/master.cf
+    marker: "# {mark} ANSIBLE SES TRANSPORT"
+    insertafter: EOF
+    block: |
+      ses      unix  -       n       n       -       -       pipe
+                flags=Rq user=ses argv=/usr/local/bin/ses_wrapper.sh ${recipient}
+    validate: 'postfix check -q %s'
   notify: Restart Postfix
 
 - name: Create directory /etc/postfix/sasl/


### PR DESCRIPTION
📝 Updated Postfix role documentation

Added and updated default values for various Postfix settings:
- Added alias_database, compatibility_level, delay_warning_time
- Updated maximal_queue_lifetime to 30d
- Added inet_interfaces, inet_protocols, myhostname, mynetworks, myorigin
- Changed recipient_delimiter to '+-'
- Removed relayhost default
- Added smtp_bind_address6, smtpd_banner, smtpd_relay_restrictions, smtpd_tls_ciphers, tls_preempt_cipherlist