### PR TITLE
📚️ Update Ansible role docs

### DIFF
--- a/roles/postfix/README.md
+++ b/roles/postfix/README.md
@@ -25,31 +25,44 @@ Role to configure Postfix.
 
 ```YAML
 postfix_static_settings:
+  alias_database:
   append_dot_mydomain:
   biff:
   body_checks: pcre:/etc/postfix/checks/body_checks.pcre
   bounce_queue_lifetime: 3d
-  default_transport:
+  compatibility_level: '3.6'
+  delay_warning_time: '0'
   header_checks: pcre:/etc/postfix/checks/header_checks.pcre
   header_size_limit: '4096000'
-  maximal_queue_lifetime: 5d
+  inet_interfaces:
+  inet_protocols:
+  maximal_queue_lifetime: 30d
   message_size_limit: '52428800'
   mime_header_checks: pcre:/etc/postfix/checks/mime_header_checks.pcre
+  myhostname: '{{ hostname }}'
+  mynetworks: 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
+  myorigin: $myhostname
   readme_directory:
   recipient_canonical_maps: pcre:/etc/postfix/recipient-canonical-maps.pcre
-  recipient_delimiter: '-'
-  relayhost: '[email-smtp.us-east-1.amazonaws.com]:587'
-  smtp_sasl_auth_enable: yes
-  smtp_sasl_password_maps: hash:/etc/postfix/sasl/sasl_passwd
-  smtp_sasl_security_options: noanonymous
-  smtp_tls_CAfile: /etc/ssl/certs/ca-certificates.crt
-  smtp_tls_ciphers: high
-  smtp_tls_note_starttls_offer: yes
-  smtp_tls_security_level: encrypt
-  smtp_use_tls: yes
+  recipient_delimiter: +-
+  relayhost:
+  smtp_bind_address6:
+  smtp_sasl_auth_enable:
+  smtp_sasl_password_maps:
+  smtp_sasl_security_options:
+  smtp_tls_CAfile:
+  smtp_tls_ciphers:
+  smtp_tls_note_starttls_offer:
+  smtp_tls_security_level:
+  smtp_use_tls:
+  smtpd_banner: $myhostname ESMTP
+  smtpd_relay_restrictions:
+    permit_mynetworks,permit_sasl_authenticated,reject_unauth_destination
   smtpd_sasl_auth_enable: yes
+  smtpd_tls_ciphers:
   smtputf8_enable: yes
-  transport_maps:
+  tls_preempt_cipherlist:
+  transport_maps: pcre:/etc/postfix/transport.pcre
 ```
 
 ## Dependencies


### PR DESCRIPTION
📝 Updated Postfix role documentation with new defaults and options

Added several new default configuration values including:
- alias_database, compatibility_level, delay_warning_time
- inet_interfaces, inet_protocols, maximal_queue_lifetime (changed to 30d)
- myhostname, mynetworks, myorigin
- Updated recipient_delimiter to +-
- Added smtpd_banner and smtpd_relay_restrictions with default values
- Added smtpd_tls_ciphers, tls_preempt_cipherlist, and transport_maps with pcre mapping
- Removed specific AWS relayhost configuration and other SASL/TLS settings