### PR TITLE
⬆️ Pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         args: ["--unsafe"]
       - id: check-added-large-files
   - repo: https://github.com/ansible-community/ansible-lint
-    rev: v25.11.0
+    rev: v25.11.1
     hooks:
       - id: ansible-lint
   - repo: https://github.com/IamTheFij/ansible-pre-commit
@@ -39,7 +39,7 @@ repos:
       - id: detect-secrets
         args: [--baseline, .config/.secrets.baseline]
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.29.1
+    rev: v8.30.0
     hooks:
       - id: gitleaks
   - repo: https://github.com/PrincetonUniversity/blocklint


### PR DESCRIPTION

✨ Fresh pre-commit hook updates

Updated ansible-lint to v25.11.1 and gitleaks to v8.30.0.
These updates will keep our code sparkling and secrets safe!
Let's maintain a pristine commit history, shall we? 😉