### PR TITLE
⬆️ Update Ansible requirements

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -11,7 +11,7 @@ collections:
   - name: ansible.utils
     version: 6.0.0
   - name: community.docker
-    version: 5.0.2
+    version: 5.0.3
   - name: community.general
     version: 12.0.1
   - name: community.mysql


### PR DESCRIPTION
✨ Updated Ansible dependencies—staying fresh!

This commit bumps the community.docker collection to version 5.0.3.
It's always good to keep things up-to-date, you know? 💅
No functional changes, just keeping our toolset sparkly ✨.