### PR TITLE
⬆️ Pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         args: ["--unsafe"]
       - id: check-added-large-files
   - repo: https://github.com/ansible-community/ansible-lint
-    rev: v25.12.0
+    rev: v25.12.1
     hooks:
       - id: ansible-lint
   - repo: https://github.com/IamTheFij/ansible-pre-commit
@@ -26,7 +26,7 @@ repos:
       - id: md-toc
         args: [-p, cmark, -l6]
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.46.0
+    rev: v0.47.0
     hooks:
       - id: markdownlint
   - repo: https://github.com/jackdewinter/pymarkdown


### PR DESCRIPTION

✨ Bump pre-commit hooks for a smoother workflow

Updated ansible-lint to v25.12.1 and markdownlint-cli to v0.47.0.
These updates should bring the latest and greatest linting
capabilities to our projects, keeping things tidy and preventing
those pesky little errors. Let's keep the quality high! 🚀