### PR TITLE
⬆️ Pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         args: ["--unsafe"]
       - id: check-added-large-files
   - repo: https://github.com/ansible-community/ansible-lint
-    rev: v25.12.2
+    rev: v26.1.0
     hooks:
       - id: ansible-lint
   - repo: https://github.com/IamTheFij/ansible-pre-commit


### PR DESCRIPTION

✨ Bumping pre-commit hooks for a smoother experience

Updated ansible-lint to v26.1.0 and kept check-added-large-files
with --unsafe flag. This should keep our Ansible code sparkly
clean and our commits lean! 💅
