### PR TITLE
⬆️ Pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
     hooks:
       - id: markdownlint
   - repo: https://github.com/jackdewinter/pymarkdown
-    rev: v0.9.34
+    rev: v0.9.35
     hooks:
       - id: pymarkdown
   - repo: https://github.com/lorenzwalthert/gitignore-tidy


### PR DESCRIPTION

✨ Freshen up those pre-commit hooks!

Updated pymarkdown to v0.9.35 and ensured everything
continues to look spiffy. No big changes, just keeping
our tools sharp and our Markdown pristine 💅.