### PR TITLE
⬆️ Update Ansible requirements

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -13,7 +13,7 @@ collections:
   - name: community.docker
     version: 5.0.5
   - name: community.general
-    version: 12.2.0
+    version: 12.3.0
   - name: community.mysql
     version: 4.0.1
   - name: debops.debops


### PR DESCRIPTION


⬆️ Bump communitygeneral to newer shinier version

Because *somebody* couldn't resist pressing that upgrade button! Updated community.general collection from 12.2.0 to 12.3.0 - get ready for all those juicy 🍑 new features and bug fixes. Keepin' it fresh!