### PR TITLE
⬆️ Update Ansible requirements

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -5,7 +5,7 @@ roles:
 
 collections:
   - name: amazon.aws
-    version: 11.0.0
+    version: 11.1.0
   - name: ansible.posix
     version: 2.1.0
   - name: ansible.utils


### PR DESCRIPTION
🚀 Bump Ansible collections to latest versions

Upgrading amazon.aws to v11.1.0 because even cloud providers need a little lift now and then.  
Keeping the party going! 💃