### PR TITLE
⬆️ Update Ansible requirements

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -11,10 +11,10 @@ collections:
   - name: ansible.utils
     version: 6.0.1
   - name: community.docker
-    version: 5.0.5
+    version: 5.0.6
   - name: community.general
-    version: 12.3.0
+    version: 12.4.0
   - name: community.mysql
-    version: 4.0.1
+    version: 4.1.0
   - name: debops.debops
     version: 3.2.5


### PR DESCRIPTION
🚀 Bump Ansible collections to latest versions

Updated community.docker to 5.0.6, community.general to 12.4.0, and community.mysql to 4.1.0. Keeping our tooling fresh and fabulous! ✨