### PR TITLE
⬆️ Pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         args: ["--unsafe"]
       - id: check-added-large-files
   - repo: https://github.com/ansible-community/ansible-lint
-    rev: v26.2.0
+    rev: v26.3.0
     hooks:
       - id: ansible-lint
         language_version: python3.13


### PR DESCRIPTION
🪛 Updated pre-commit hooks in .pre-commit-config.yaml

- Upgraded ansible-lint from v26.2.0 to v26.3.0 for the latest bug fixes and improvements.
- No other hooks were modified in this update.