### PR TITLE
⬆️ Pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     hooks:
       - id: markdownlint
   - repo: https://github.com/jackdewinter/pymarkdown
-    rev: v0.9.35
+    rev: v0.9.36
     hooks:
       - id: pymarkdown
   - repo: https://github.com/lorenzwalthert/gitignore-tidy
@@ -44,7 +44,7 @@ repos:
       - id: detect-secrets
         args: [--baseline, .config/.secrets.baseline]
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.30.0
+    rev: v8.30.1
     hooks:
       - id: gitleaks
   - repo: https://github.com/PrincetonUniversity/blocklint


### PR DESCRIPTION
🚀 Upgrade pre-commit hooks to latest versions

- Upgraded pymarkdown hook from v0.9.35 to v0.9.36 for better Markdown linting
- Updated gitleaks hook from v8.30.0 to v8.30.1 for enhanced secret detection

Keeping dependencies fresh and secure, because who wants stale hooks? Not me! 😉