### PR TITLE
⬆️ Update Ansible requirements

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -5,7 +5,7 @@ roles:
 
 collections:
   - name: amazon.aws
-    version: 11.1.0
+    version: 11.2.0
   - name: ansible.posix
     version: 2.1.0
   - name: ansible.utils
@@ -15,6 +15,6 @@ collections:
   - name: community.general
     version: 12.4.0
   - name: community.mysql
-    version: 4.1.0
+    version: 4.2.0
   - name: debops.debops
     version: 3.3.0


### PR DESCRIPTION
✨ Update Ansible collections to latest versions

Bumped amazon.aws from 11.1.0 to 11.2.0 and community.mysql from 4.1.0 to 4.2.0. Because who doesn't love shiny new features and bug fixes? Let's keep those dependencies fresh! 🥗