### PR TITLE
⬆️ Update Ansible requirements

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -11,7 +11,7 @@ collections:
   - name: ansible.utils
     version: 6.0.1
   - name: community.docker
-    version: 5.1.0
+    version: 5.2.0
   - name: community.general
     version: 12.5.0
   - name: community.mysql


### PR DESCRIPTION
✨ Update community.docker to 5.2.0

Bumped community.docker from 5.1.0 to 5.2.0 to get the latest bug fixes and better performance.