### PR TITLE
⬆️ Update Ansible requirements

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -9,7 +9,7 @@ collections:
   - name: ansible.posix
     version: 2.1.0
   - name: ansible.utils
-    version: 6.0.1
+    version: 6.0.2
   - name: community.docker
     version: 5.2.0
   - name: community.general


### PR DESCRIPTION
✨ Updated Ansible collection versions

Bumped the ansible.utils collection from version **6.0.1** to **6.0.2**.  
All other roles and collections remain unchanged, keeping the playbooks fresh and ready to roll.