### PR TITLE
⬆️ Update Ansible requirements

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -13,7 +13,7 @@ collections:
   - name: community.docker
     version: 5.2.0
   - name: community.general
-    version: 12.5.0
+    version: 12.6.0
   - name: community.mysql
     version: 4.2.0
   - name: debops.debops


### PR DESCRIPTION
✨ bump community.general to 12.6.0 in requirements.yml

Add a shiny new version of **community.general** so your playbooks stay up‑to‑date and fabulous.  
No extra fluff—just the upgrade that keeps everything running smoothly.