### PR TITLE
⬆️ Pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     hooks:
       - id: markdownlint
   - repo: https://github.com/jackdewinter/pymarkdown
-    rev: v0.9.36
+    rev: v0.9.37
     hooks:
       - id: pymarkdown
   - repo: https://github.com/lorenzwalthert/gitignore-tidy
@@ -52,7 +52,7 @@ repos:
     hooks:
       - id: blocklint
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.1
+    rev: 0.37.2
     hooks:
       - id: check-github-actions
         args: [--verbose]


### PR DESCRIPTION
✨ Updated pre-commit hooks – bumped pymarkdown & check-jsonschema

Pymarkdown moved from v0.9.36 to v0.9.37—because the latest fixes linting slowness
Check-jsonschema bumped 0.37.1 → 0.37.2 to catch new schema changes
All set—your repo’s linting is now a bit snappier