### PR TITLE
📚️ Update Ansible role docs

### DIFF
--- a/roles/wp/README.md
+++ b/roles/wp/README.md
@@ -5,6 +5,9 @@ Role to configure my WordPress blog.
 ## Table of contents
 
 - [Requirements](#requirements)
+- [Default Variables](#default-variables)
+  - [wp_archive](#wp_archive)
+  - [wp_archive_dir](#wp_archive_dir)
 - [Dependencies](#dependencies)
 - [License](#license)
 - [Author](#author)
@@ -14,6 +17,24 @@ Role to configure my WordPress blog.
 ## Requirements
 
 - Minimum Ansible version: `2.1`
+
+## Default Variables
+
+### wp_archive
+
+#### Default value
+
+```YAML
+wp_archive: '{{ wp_archive_dir }}/uploads.tar.xz'
+```
+
+### wp_archive_dir
+
+#### Default value
+
+```YAML
+wp_archive_dir: /var/cache/wp-archive
+```
 
 ## Dependencies
 


### PR DESCRIPTION
📚 Updated wp role docs with default vars

Added a new “Default Variables” section to the wp role README.  
Included explanations and YAML examples for wp_archive and wp_archive_dir.  
Made the table of contents clearer by adding links to the new subsections.  

This keeps the docs tidy and helps future you (or me) spot the defaults at a glance.