### PR TITLE
⬆️ Pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     hooks:
       - id: markdownlint
   - repo: https://github.com/jackdewinter/pymarkdown
-    rev: v0.9.37
+    rev: v0.9.38
     hooks:
       - id: pymarkdown
   - repo: https://github.com/lorenzwalthert/gitignore-tidy
@@ -52,7 +52,7 @@ repos:
     hooks:
       - id: blocklint
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.2
+    rev: 0.37.3
     hooks:
       - id: check-github-actions
         args: [--verbose]


### PR DESCRIPTION
✨ Updated pre-commit hook versions

- Bumped **pymarkdown** from v0.9.37 to v0.9.38  
- Updated **check-jsonschema** from 0.37.2 to 0.37.3

All hooks stay the same, just the latest stable releases.  
Now your linting will run smoother and with the newest bug fixes.