### PR TITLE
⬆️ Pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       - id: md-toc
         args: [-p, cmark, -l6]
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.48.0
+    rev: v0.49.0
     hooks:
       - id: markdownlint
   - repo: https://github.com/jackdewinter/pymarkdown


### PR DESCRIPTION
✨ Updated markdownlint to latest version

Bumped markdownlint from v0.48.0 to v0.49.0 to keep docs pristine  
No other hooks changed—just a quick fix for the latest lint rules