### PR TITLE
⬆️ Update Ansible requirements

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -5,7 +5,7 @@ roles:
 
 collections:
   - name: amazon.aws
-    version: 11.3.0
+    version: 11.4.0
   - name: ansible.posix
     version: 2.2.0
   - name: ansible.utils
@@ -15,6 +15,6 @@ collections:
   - name: community.general
     version: 13.1.0
   - name: ansible.mysql
-    version: 5.0.1
+    version: 5.1.0
   - name: debops.debops
     version: 3.3.0


### PR DESCRIPTION
✨ Bump amazon.aws to 11.4.0 and ansible.mysql to 5.1.0

Upgraded the *amazon.aws* collection from 11.3.0 to 11.4.0, adding a few new features and bug fixes.  
Also bumped *ansible.mysql* from 5.0.1 to 5.1.0 so the MySQL modules stay fresh.  

No other changes – just keeping dependencies happy.