### PR TITLE
⬆️ Pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         args: ["--unsafe"]
       - id: check-added-large-files
   - repo: https://github.com/ansible-community/ansible-lint
-    rev: v26.4.0
+    rev: v26.6.0
     hooks:
       - id: ansible-lint
         language_version: python3.13
@@ -52,7 +52,7 @@ repos:
     hooks:
       - id: blocklint
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.3
+    rev: 0.37.4
     hooks:
       - id: check-github-actions
         args: [--verbose]


### PR DESCRIPTION
🎉 Updated pre-commit hook revisions

Spice up the repo with newer hook versions:
- ansible‑lint bumped from v26.4.0 to v26.6.0 — because 26.6 is slicker
- check‑jsonschema now on 0.37.4 — the latest and greatest

All other hooks stay exactly the same, so no surprises