### PR TITLE
feat: support manual branch docs updates

### DIFF
--- a/.github/actions/create-or-update-pr/action.yml
+++ b/.github/actions/create-or-update-pr/action.yml
@@ -6,6 +6,10 @@ inputs:
   branch:
     description: "Branch to push changes to"
     required: true
+  create_pr:
+    description: "Whether to create or update a pull request"
+    required: false
+    default: "true"
   commit_message:
     description: "Full commit message"
     required: true
@@ -47,7 +51,14 @@ runs:
 
         git config user.name "${INPUTS_GIT_USER_NAME}"
         git config user.email "${INPUTS_GIT_USER_EMAIL}"
-        git checkout -B "${INPUTS_BRANCH}"
+
+        if git show-ref --verify --quiet "refs/heads/${INPUTS_BRANCH}"; then
+          git checkout "${INPUTS_BRANCH}"
+        elif git show-ref --verify --quiet "refs/remotes/origin/${INPUTS_BRANCH}"; then
+          git checkout -B "${INPUTS_BRANCH}" "origin/${INPUTS_BRANCH}"
+        else
+          git checkout -b "${INPUTS_BRANCH}"
+        fi
 
         if git diff --cached --quiet; then
           echo "🟡 No staged changes to commit."
@@ -61,7 +72,9 @@ runs:
         fi
 
     - shell: bash
-      if: steps.commit_push.outputs.pushed == 'true'
+      if: |
+        steps.commit_push.outputs.pushed == 'true' &&
+        inputs.create_pr == 'true'
       env:
         GH_TOKEN: ${{ inputs.github_token }}
         INPUTS_BRANCH: ${{ inputs.branch }}

--- a/.github/workflows/ansible-doctor.yml
+++ b/.github/workflows/ansible-doctor.yml
@@ -104,7 +104,14 @@ jobs:
         uses: ./.github/actions/create-or-update-pr
         if: steps.changes.outputs.has_changes == 'true'
         with:
-          branch: chore/ansible-docs
+          branch: >-
+            ${{ github.event_name == 'workflow_dispatch'
+                && github.ref_name != 'main'
+                && github.ref_name
+                || 'chore/ansible-docs' }}
+          create_pr: >-
+            ${{ !(github.event_name == 'workflow_dispatch'
+                && github.ref_name != 'main') }}
           commit_message: ${{ steps.ai_commit.outputs.message }}
           pr_title: "📚️ Update Ansible role docs"
           pr_body: ${{ steps.ai_commit.outputs.message }}


### PR DESCRIPTION
## Summary
- allow the ansible-docs workflow to target the selected branch for manual non-main runs
- skip PR creation in that manual non-main path so commits stay on the chosen branch
- preserve the existing chore branch behavior for main-triggered runs

## Testing
- Verified the updated workflow and composite action YAML files parse successfully.