### PR TITLE
⬆️ Pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     hooks:
       - id: markdownlint
   - repo: https://github.com/jackdewinter/pymarkdown
-    rev: v0.9.38
+    rev: v0.9.39
     hooks:
       - id: pymarkdown
   - repo: https://github.com/lorenzwalthert/gitignore-tidy


### PR DESCRIPTION
🎉 Updated pymarkdown to v0.9.39 for fresher linting

Bumped the pymarkdown hook from v0.9.38 to v0.9.39 — because stale linters
are like expired milk, nobody wants that. The markdownlint hook stays
put since it's already doing its job like a champ.