### PR TITLE
⬆️ Super-Linter

### DIFF
--- a/roles/mailinabox_dns/handlers/main.yml
+++ b/roles/mailinabox_dns/handlers/main.yml
@@ -3,3 +3,4 @@
   ansible.builtin.command:
     cmd: /root/mailinabox/tools/dns_update --force
   changed_when: true
+  when: mailinabox_dns_update.stat.exists

--- a/roles/mailinabox_dns/tasks/main.yml
+++ b/roles/mailinabox_dns/tasks/main.yml
@@ -7,6 +7,11 @@
     group: root
     mode: "0755"
 
+- name: Check if dns_update exists
+  ansible.builtin.stat:
+    path: /root/mailinabox/tools/dns_update
+  register: mailinabox_dns_update
+
 - name: Copy custom DNS settings
   ansible.builtin.copy:
     src: custom.yaml

--- a/roles/mailinabox_duplicity/handlers/main.yml
+++ b/roles/mailinabox_duplicity/handlers/main.yml
@@ -3,3 +3,4 @@
   ansible.builtin.command:
     cmd: /root/mailinabox/management/backup.py
   changed_when: true
+  when: mailinabox_duplicity_backup_py.stat.exists

--- a/roles/mailinabox_duplicity/tasks/main.yml
+++ b/roles/mailinabox_duplicity/tasks/main.yml
@@ -20,6 +20,11 @@
     group: root
     mode: "0700"
 
+- name: Check if backup.py exists
+  ansible.builtin.stat:
+    path: /root/mailinabox/management/backup.py
+  register: mailinabox_duplicity_backup_py
+
 - name: Configure Duplicity
   ansible.builtin.template:
     src: custom.yaml.j2


### PR DESCRIPTION
## 🤖 Automated Super-Linter Fixes

🛡️ Add safety checks for Mail-in-a-Box scripts before running handlers

Prevent handlers from faceplanting when dns_update or backup.py are missing  
Stat tasks now verify script existence before handlers try to execute them  
Fresh installs and partial setups won't throw tantrums anymore

---
**Diff included in workflow summary.**
