### PR TITLE
📚️ Update Ansible role docs

### DIFF
--- a/roles/dovecot/README.md
+++ b/roles/dovecot/README.md
@@ -1,4 +1,4 @@
-# mailinabox_dovecot
+# dovecot
 
 Dovecot-related maintenance tasks for Mail-in-a-Box, including mailbox expunge
 jobs and helper scripts scheduled via /etc/cron.d.


### PR DESCRIPTION
📝 Simplified role title to just dovecot

Dropped the redundant mailinabox_ prefix since the role lives in a Mail-in-a-Box context anyway
Keeps things clean and lets the role name speak for itself