### PR TITLE
⬆️ Super-Linter

### DIFF
--- a/roles/mailinabox_dovecot/README.md
+++ b/roles/mailinabox_dovecot/README.md
@@ -1,0 +1,29 @@
+# mailinabox_dovecot
+
+Dovecot-related maintenance tasks for Mail-in-a-Box, including mailbox expunge
+jobs and helper scripts scheduled via /etc/cron.d.
+
+## Table of contents
+
+- [Requirements](#requirements)
+- [Dependencies](#dependencies)
+- [License](#license)
+- [Author](#author)
+
+---
+
+## Requirements
+
+- Minimum Ansible version: `2.16`
+
+## Dependencies
+
+None.
+
+## License
+
+MIT
+
+## Author
+
+[Amedee Van Gasse](https://amedee.be)

--- a/roles/mailinabox_dovecot/files/doveadm_expunge.cron
+++ b/roles/mailinabox_dovecot/files/doveadm_expunge.cron
@@ -1,0 +1,2 @@
+@daily root /usr/bin/doveadm expunge -A mailbox Spam before 30d
+@daily root /usr/bin/doveadm expunge -A mailbox Trash before 30d

--- a/roles/mailinabox_dovecot/files/extract_image_attachments.cron
+++ b/roles/mailinabox_dovecot/files/extract_image_attachments.cron
@@ -1,0 +1,1 @@
+@daily root /usr/local/bin/extract_image_attachments.sh

--- a/roles/mailinabox_dovecot/files/extract_image_attachments.sh
+++ b/roles/mailinabox_dovecot/files/extract_image_attachments.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+MAILDIR='/home/user-data/mail/mailboxes/vangasse.eu/amedee/.Spam/cur/'
+SAVED_ATTACHMENTS='/root/attachments/'
+
+function cleanup() {
+	cd "$HOME" || exit
+	rm --force --recursive "$ATTACHMENTS_DIR"
+}
+trap cleanup EXIT
+
+ATTACHMENTS_DIR=$(mktemp --directory -t attachments-XXXX) || exit 1
+mkdir --parents "$SAVED_ATTACHMENTS" || exit 1
+cd "$ATTACHMENTS_DIR" || exit
+
+(
+	grep --files-with-matches --recursive --null --extended-regexp --regexp='Content-Type: (image|video)' "$MAILDIR" |
+		xargs --null --max-args=1 munpack
+) &>/dev/null
+rm --force ./*.desc*
+fdupes --hardlinks --noempty --order=name --delete --noprompt --quiet .
+rsync --archive --ignore-missing-args ./*.jpeg* ./*.jpg* ./*.png* ./*.mp4* "$SAVED_ATTACHMENTS"

--- a/roles/mailinabox_dovecot/meta/main.yml
+++ b/roles/mailinabox_dovecot/meta/main.yml
@@ -1,0 +1,21 @@
+---
+# @meta author:value: [Amedee Van Gasse](https://amedee.be)
+galaxy_info:
+  description: >
+    Dovecot-related maintenance tasks for Mail-in-a-Box, including
+    mailbox expunge jobs and helper scripts scheduled via /etc/cron.d.
+  author: Amedee Van Gasse
+  license: MIT
+  min_ansible_version: "2.16"
+
+  platforms:
+    - name: Ubuntu
+      versions:
+        - jammy
+
+  galaxy_tags:
+    - mail
+    - dovecot
+    - mailinabox
+    - cron
+    - maintenance

--- a/roles/mailinabox_dovecot/tasks/cron.yml
+++ b/roles/mailinabox_dovecot/tasks/cron.yml
@@ -1,0 +1,30 @@
+---
+- name: Configure cron jobs for Dovecot expunge
+  ansible.builtin.copy:
+    src: doveadm_expunge.cron
+    dest: /etc/cron.d/doveadm_expunge
+    mode: "0644"
+    owner: root
+    group: root
+
+- name: Install tools required for image extraction
+  ansible.builtin.apt:
+    name:
+      - fdupes
+      - mpack
+
+- name: Copy script for image extraction
+  ansible.builtin.copy:
+    src: extract_image_attachments.sh
+    dest: /usr/local/bin/extract_image_attachments.sh
+    mode: "0755"
+    owner: root
+    group: root
+
+- name: Configure cron jobs for image extraction
+  ansible.builtin.copy:
+    src: extract_image_attachments.cron
+    dest: /etc/cron.d/extract_image_attachments
+    mode: "0644"
+    owner: root
+    group: root

--- a/roles/mailinabox_dovecot/tasks/main.yml
+++ b/roles/mailinabox_dovecot/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Configure cron jobs for Dovecot
+  ansible.builtin.import_tasks: cron.yml


### PR DESCRIPTION
## 🤖 Automated Super-Linter Fixes

📧 Add Dovecot maintenance role for Mail-in-a-Box

This new role handles the boring but essential Dovecot cleanup so I don't
have to think about it. It sets up daily cron jobs to expunge old Spam
and Trash messages (30 days, bye Felicia 👋), plus a nifty script that
extracts image and video attachments from the Spam folder for... reasons.
Probably just to see what kind of garbage spammers are sending these days.
Includes all the Ansible goodness: tasks, meta, and a README because
documentation is actually cool now.

---
**Diff included in workflow summary.**
