### PR TITLE
⬆️ Super-Linter

### DIFF
--- a/.github/actions/restore-ansible-cache/action.yml
+++ b/.github/actions/restore-ansible-cache/action.yml
@@ -1,12 +1,21 @@
 ---
 name: ♻️ Restore Ansible Cache
-description: Restores and relocates Ansible role/collection cache
+description: Restores and installs Ansible Galaxy dependencies
+
+outputs:
+  cache-hit:
+    description: Whether the cache was restored from an exact match
+    value: ${{ steps.cache.outputs.cache-hit }}
+  cache-primary-key:
+    description: Primary cache key
+    value: ${{ steps.cache.outputs.cache-primary-key }}
 
 runs:
-  using: "composite"
+  using: composite
   steps:
     - name: Restore Ansible roles and collections cache
-      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      id: cache
+      uses: actions/cache/restore@v5
       with:
         path: |
           /home/runner/.ansible/collections

--- a/.github/actions/restore-ansible-cache/action.yml
+++ b/.github/actions/restore-ansible-cache/action.yml
@@ -15,7 +15,7 @@ runs:
   steps:
     - name: Restore Ansible roles and collections cache
       id: cache
-      uses: actions/cache/restore@v5
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
       with:
         path: |
           /home/runner/.ansible/collections

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -11,9 +11,6 @@ on: # yamllint disable-line rule:truthy
       - "!.github/workflows/ansible-doctor.yml"
       - "!.github/workflows/gource.yml"
       - "!.pre-commit-config.yaml"
-      - "!Vagrantfile"
-      - "!deploy_to_staging.sh"
-      - "!resize_disk.sh"
   schedule:
     - cron: "10 3 * * SAT"
   workflow_dispatch:
@@ -26,6 +23,10 @@ permissions:
   contents: read
 
 jobs:
+  preheat-ansible-cache:
+    name: 🔥 Preheat Ansible Cache
+    uses: ./.github/workflows/preheat-ansible-cache.yml
+
   super-linter:
     name: 🛠️ Code Quality — Super-Linter
     permissions:
@@ -35,17 +36,10 @@ jobs:
       pull-requests: write
       statuses: write
     uses: ./.github/workflows/code-quality-super-linter.yml
+    needs: preheat-ansible-cache
     secrets:
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       ANSIBLE_DEP_UPDATER_TOKEN: ${{ secrets.ANSIBLE_DEP_UPDATER_TOKEN }}
-
-  ansible-lint:
-    name: 🛠️ Code Quality — Ansible Lint
-    uses: ./.github/workflows/code-quality-ansible-lint.yml
-
-  molecule:
-    name: 🧪 Molecule Tests
-    uses: ./.github/workflows/molecule.yml
 
   eslint:
     name: 🛠️ Code Quality — ESLint
@@ -63,10 +57,21 @@ jobs:
     name: 🛠️ Code Quality — Pre-Commit
     uses: ./.github/workflows/code-quality-pre-commit.yml
 
+  ansible-lint:
+    name: 🛠️ Code Quality — Ansible Lint
+    uses: ./.github/workflows/code-quality-ansible-lint.yml
+    needs: preheat-ansible-cache
+
+  molecule:
+    name: 🧪 Molecule Tests
+    uses: ./.github/workflows/molecule.yml
+    needs: preheat-ansible-cache
+
   deploy:
     name: 🚀 Deploy to Production
     uses: ./.github/workflows/ansible-run.yml
     needs:
+      - preheat-ansible-cache
       - super-linter
       - ansible-lint
       - molecule

--- a/.github/workflows/preheat-ansible-cache.yml
+++ b/.github/workflows/preheat-ansible-cache.yml
@@ -1,0 +1,34 @@
+---
+name: 🔥 Preheat Ansible Cache
+
+on: # yamllint disable-line rule:truthy
+  workflow_call:
+  workflow_dispatch:
+
+concurrency:
+  group: ansible-cache-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  ansible-cache:
+    name: Warm Ansible dependency cache
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Restore Ansible cache
+        id: restore
+        uses: ./.github/actions/restore-ansible-cache
+
+      - name: Save Ansible cache
+        if: steps.restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            /home/runner/.ansible/collections
+            /home/runner/.ansible/roles
+          key: ${{ steps.restore.outputs.cache-primary-key }}

--- a/.github/workflows/preheat-ansible-cache.yml
+++ b/.github/workflows/preheat-ansible-cache.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Restore Ansible cache
         id: restore


### PR DESCRIPTION
## 🤖 Automated Super-Linter Fixes

🔒 Pin actions to SHAs and disable credential persistence

Switched the cache restore action to a pinned commit SHA instead of a floating tag — because supply chain attacks are *so* last season. Also told checkout to stop hoarding credentials with persist-credentials: false. Less surface area, fewer surprises, same great taste.

---
**Diff included in workflow summary.**
