### PR TITLE
⬆️ Super-Linter

### DIFF
--- a/.github/workflows/preheat-ansible-cache.yml
+++ b/.github/workflows/preheat-ansible-cache.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Restore Ansible cache
         id: restore


### PR DESCRIPTION
## 🤖 Automated Super-Linter Fixes

🔒 Stop persisting checkout credentials for security

Added persist-credentials: false to the checkout step so GitHub tokens don't linger around longer than needed. Cleaner and safer!

---
**Diff included in workflow summary.**
