### PR TITLE
📚️ Update Ansible role docs

### DIFF
--- a/roles/imapsync/README.md
+++ b/roles/imapsync/README.md
@@ -1,6 +1,7 @@
 # imapsync
 
-Role to configure imapsync.
+Role to configure imapsync. See the upstream installation instructions:
+[imapsync Ubuntu installation instructions](https://imapsync.lamiral.info/INSTALL.d/INSTALL.Ubuntu.txt)
 
 ## Table of contents
 
@@ -9,6 +10,7 @@ Role to configure imapsync.
   - [imapsync_creds_path](#imapsync_creds_path)
   - [imapsync_install_path](#imapsync_install_path)
   - [imapsync_log_file](#imapsync_log_file)
+  - [imapsync_packages](#imapsync_packages)
   - [imapsync_script_path](#imapsync_script_path)
   - [imapsync_upstream_url](#imapsync_upstream_url)
 - [Dependencies](#dependencies)
@@ -45,6 +47,55 @@ imapsync_install_path: /usr/local/bin/imapsync
 
 ```YAML
 imapsync_log_file: /var/log/imapsync.log
+```
+
+### imapsync_packages
+
+#### Default value
+
+```YAML
+imapsync_packages:
+  - cpanminus
+  - libauthen-ntlm-perl
+  - libclass-load-perl
+  - libcrypt-openssl-rsa-perl
+  - libcrypt-ssleay-perl
+  - libdata-uniqid-perl
+  - libdigest-hmac-perl
+  - libdist-checkconflicts-perl
+  - libencode-imaputf7-perl
+  - libfile-copy-recursive-perl
+  - libfile-tail-perl
+  - libio-compress-perl
+  - libio-socket-inet6-perl
+  - libio-socket-ssl-perl
+  - libio-tee-perl
+  - libjson-webtoken-perl
+  - libmail-imapclient-perl
+  - libmodule-scandeps-perl
+  - libnet-dbus-perl
+  - libnet-dns-perl
+  - libnet-ssleay-perl
+  - libpar-packer-perl
+  - libproc-processtable-perl
+  - libreadonly-perl
+  - libregexp-common-perl
+  - libsys-meminfo-perl
+  - libterm-readkey-perl
+  - libtest-deep-perl
+  - libtest-fatal-perl
+  - libtest-mock-guard-perl
+  - libtest-mockobject-perl
+  - libtest-nowarnings-perl
+  - libtest-pod-perl
+  - libtest-requires-perl
+  - libtest-simple-perl
+  - libtest-warn-perl
+  - libunicode-string-perl
+  - liburi-perl
+  - make
+  - time
+  - wget
 ```
 
 ### imapsync_script_path


### PR DESCRIPTION
📚 Docs: add imapsync packages list and upstream link

Finally documented the massive pile of Perl dependencies this role needs to function
Added a handy link to the official Ubuntu install guide so future me doesn't have to
hunt it down again. The imapsync_packages variable now shows all 40+ packages
required for a successful build — because nobody likes mysterious build failures.