### PR TITLE
📚️ Update Ansible role docs

### DIFF
--- a/roles/letsencrypt/README.md
+++ b/roles/letsencrypt/README.md
@@ -5,6 +5,9 @@ Role to configure letsencrypt.
 ## Table of contents
 
 - [Requirements](#requirements)
+- [Default Variables](#default-variables)
+  - [letsencrypt_primary_domain](#letsencrypt_primary_domain)
+  - [letsencrypt_restore_from_backup](#letsencrypt_restore_from_backup)
 - [Dependencies](#dependencies)
 - [License](#license)
 - [Author](#author)
@@ -14,6 +17,24 @@ Role to configure letsencrypt.
 ## Requirements
 
 - Minimum Ansible version: `2.1`
+
+## Default Variables
+
+### letsencrypt_primary_domain
+
+#### Default value
+
+```YAML
+letsencrypt_primary_domain: amedee.be
+```
+
+### letsencrypt_restore_from_backup
+
+#### Default value
+
+```YAML
+letsencrypt_restore_from_backup: true
+```
 
 ## Dependencies
 


### PR DESCRIPTION
📝 Docs: add default variables to letsencrypt role README

Finally documented those mysterious default vars that everyone asks about
Added letsencrypt_primary_domain and letsencrypt_restore_from_backup
to the README with their default values so you can stop guessing
No more digging through defaults/main.yml like a detective
Your future self will thank you for this clarity