### PR TITLE
⬆️ Super-Linter

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -73,9 +73,11 @@ jobs:
     outputs:
       production: ${{ steps.filter.outputs.production }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: filter
         with:
           filters: |


### PR DESCRIPTION
## 🤖 Automated Super-Linter Fixes

🔒 Pin GitHub Actions to commit SHAs for supply chain security

Switched actions/checkout and dorny/paths-filter from version tags to immutable commit SHAs — because trusting floating tags is so last season. Also told checkout to stop persisting credentials since this workflow doesn't need 'em. Safety first, sass always.

---
**Diff included in workflow summary.**
