### PR TITLE
📚️ Update Ansible role docs

### DIFF
--- a/roles/duplicity/README.md
+++ b/roles/duplicity/README.md
@@ -5,6 +5,9 @@ Role to do configuration of duplicity backup of mailinabox.
 ## Table of contents
 
 - [Requirements](#requirements)
+- [Default Variables](#default-variables)
+  - [duplicity_backup_age](#duplicity_backup_age)
+  - [duplicity_backup_target](#duplicity_backup_target)
 - [Dependencies](#dependencies)
 - [License](#license)
 - [Author](#author)
@@ -14,6 +17,24 @@ Role to do configuration of duplicity backup of mailinabox.
 ## Requirements
 
 - Minimum Ansible version: `2.1`
+
+## Default Variables
+
+### duplicity_backup_age
+
+#### Default value
+
+```YAML
+duplicity_backup_age: 3
+```
+
+### duplicity_backup_target
+
+#### Default value
+
+```YAML
+duplicity_backup_target: s3://s3.us-east-1.amazonaws.com/backups-by-amedee/mail-in-a-box
+```
 
 ## Dependencies
 


### PR DESCRIPTION
📝 Document duplicity backup defaults like a boss

Added **Default Variables** section to the table of contents  
Documented duplicity_backup_age with its 3-day retention default  
Documented duplicity_backup_target pointing to the S3 mail-in-a-box bucket  
No more guessing games — the config speaks for itself now