### PR TITLE
📚️ Update Ansible role docs

### DIFF
--- a/roles/mailinabox_ufw/README.md
+++ b/roles/mailinabox_ufw/README.md
@@ -1,6 +1,8 @@
 # mailinabox_ufw
 
-Role to silence mailinabox about not being able to use port 25.
+Work around Mail-in-a-Box's outbound SMTP connectivity check by redirecting
+outbound TCP/25 to localhost. Intended for servers that send mail via an SMTP
+relay or API instead of direct SMTP delivery.
 
 ## Table of contents
 


### PR DESCRIPTION
📝 docs: actually explain what mailinabox_ufw does — relay style

Swapped the cryptic one-liner for a real description that admits this role
redirects outbound port 25 to localhost so Mail-in-a-Box stops nagging
Perfect for when you're sending mail via relay or API instead of raw SMTP
No more guessing games — the README now tells it like it is