### PR TITLE
⬆️ Super-Linter

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,10 +1,7 @@
 {
 	"threshold": 5,
 	"reporters": ["html", "console", "markdown"],
-	"ignore": [
-		"**/.ansible/**",
-		"**/molecule/**"
-	],
+	"ignore": ["**/.ansible/**", "**/molecule/**"],
 	"absolute": true,
 	"gitignore": true
 }


### PR DESCRIPTION
## 🤖 Automated Super-Linter Fixes

✨ tidy up jscpd ignore patterns formatting

Condensed the ignore array into a clean single line because vertical space is precious and I have opinions about JSON aesthetics. The config still ignores Ansible and Molecule directories like before, just with less visual noise.

---
**Diff included in workflow summary.**
