### PR TITLE
📚️ Update Ansible role docs

### DIFF
--- a/roles/mysql/README.md
+++ b/roles/mysql/README.md
@@ -5,6 +5,8 @@ Role to install and configure a MySQL database server.
 ## Table of contents
 
 - [Requirements](#requirements)
+- [Default Variables](#default-variables)
+  - [mysql_disable_binary_logging](#mysql_disable_binary_logging)
 - [Dependencies](#dependencies)
 - [License](#license)
 - [Author](#author)
@@ -14,6 +16,16 @@ Role to install and configure a MySQL database server.
 ## Requirements
 
 - Minimum Ansible version: `2.1`
+
+## Default Variables
+
+### mysql_disable_binary_logging
+
+#### Default value
+
+```YAML
+mysql_disable_binary_logging: true
+```
 
 ## Dependencies
 


### PR DESCRIPTION
📝 Document mysql_disable_binary_logging default in README

Finally added the missing Default Variables section to the MySQL role README
because apparently I enjoy leaving folks guessing about defaults 🤷‍♂️

Now mysql_disable_binary_logging is properly documented with its default
value of true — because binary logging is great until it fills your disk
and you're crying at 3 AM 😅

No more digging through defaults/main.yml like a detective 🕵️‍♂️