### PR TITLE
📚️ Update Ansible role docs

### DIFF
--- a/roles/munin_node/README.md
+++ b/roles/munin_node/README.md
@@ -5,6 +5,8 @@ Role to configure munin-node.
 ## Table of contents
 
 - [Requirements](#requirements)
+- [Default Variables](#default-variables)
+  - [munin_node_server_ip](#munin_node_server_ip)
 - [Dependencies](#dependencies)
 - [License](#license)
 - [Author](#author)
@@ -14,6 +16,16 @@ Role to configure munin-node.
 ## Requirements
 
 - Minimum Ansible version: `2.1`
+
+## Default Variables
+
+### munin_node_server_ip
+
+#### Default value
+
+```YAML
+munin_node_server_ip: 142.93.227.16
+```
 
 ## Dependencies
 


### PR DESCRIPTION
📝 Docs: spice up munin_node README with default variable deets

Added a shiny new **Default Variables** section documenting munin_node_server_ip
with its default value (142.93.227.16) so future me doesn't have to guess
what the Munin server IP should be. Also tweaked the table of contents to
actually link to it. Documentation that doesn't suck? Yes please.