### PR TITLE
📚️ Update Ansible role docs

### DIFF
--- a/roles/nginx/README.md
+++ b/roles/nginx/README.md
@@ -5,6 +5,16 @@ Role to configure nginx.
 ## Table of contents
 
 - [Requirements](#requirements)
+- [Default Variables](#default-variables)
+  - [nginx_apt_pinning_files](#nginx_apt_pinning_files)
+  - [nginx_apt_suite](#nginx_apt_suite)
+  - [nginx_config_files](#nginx_config_files)
+  - [nginx_default_indexfiles](#nginx_default_indexfiles)
+  - [nginx_directory](#nginx_directory)
+  - [nginx_hostname](#nginx_hostname)
+  - [nginx_php_version](#nginx_php_version)
+  - [nginx_repositories](#nginx_repositories)
+  - [nginx_user](#nginx_user)
 - [Dependencies](#dependencies)
 - [License](#license)
 - [Author](#author)
@@ -14,6 +24,96 @@ Role to configure nginx.
 ## Requirements
 
 - Minimum Ansible version: `2.1`
+
+## Default Variables
+
+### nginx_apt_pinning_files
+
+#### Default value
+
+```YAML
+nginx_apt_pinning_files:
+  - pin_nginx.pref
+  - pin_php.pref
+```
+
+### nginx_apt_suite
+
+#### Default value
+
+```YAML
+nginx_apt_suite: '{{ ansible_distribution_release }}'
+```
+
+### nginx_config_files
+
+#### Default value
+
+```YAML
+nginx_config_files:
+  - src: nginx.conf
+    dest: /etc/nginx/nginx.conf
+  - src: gzip.conf
+    dest: /etc/nginx/conf.d/gzip.conf
+```
+
+### nginx_default_indexfiles
+
+#### Default value
+
+```YAML
+nginx_default_indexfiles:
+  - index.php
+  - index.html
+```
+
+### nginx_directory
+
+#### Default value
+
+```YAML
+nginx_directory: '{{ webserver_directory }}'
+```
+
+### nginx_hostname
+
+#### Default value
+
+```YAML
+nginx_hostname: '{{ hostname }}'
+```
+
+### nginx_php_version
+
+#### Default value
+
+```YAML
+nginx_php_version: '{{ php_version }}'
+```
+
+### nginx_repositories
+
+#### Default value
+
+```YAML
+nginx_repositories:
+  - name: nginx
+    uri: https://nginx.org/packages/ubuntu
+    component: nginx
+    key: https://nginx.org/keys/nginx_signing.key
+  - name: sury-php
+    uri: https://packages.sury.org/php/
+    component: main
+    key: https://packages.sury.org/php/apt.gpg
+```
+
+### nginx_user
+
+#### Default value
+
+```YAML
+nginx_user: "{{ webserver_user | default('www-data') }}"
+```
 
 ## Dependencies
 


### PR DESCRIPTION
📝 Document nginx role default variables like a boss

Added a shiny new **Default Variables** section to the nginx role README
with detailed docs for every configurable option. Each variable now shows
its default value in clean YAML snippets — because guessing games are for
amateurs, not automation wizards.

Variables covered:
- nginx_apt_pinning_files — pin those packages tight
- nginx_apt_suite — dynamic distro release detection FTW
- nginx_config_files — drop-in configs with source/dest mapping
- nginx_default_indexfiles — PHP first, HTML second, obviously
- nginx_directory — respects the webserver directory convention
- nginx_hostname — inherits from system hostname like a good citizen
- nginx_php_version — syncs with the global PHP version var
- nginx_repositories — official nginx + Sury PHP repos, keys included
- nginx_user — falls back to www-data if webserver_user missing

No more digging through tasks to find defaults. Documentation that
actually helps? Imagine that.