### PR TITLE
test(postfix_ses): add Docker-based Molecule tests for SES routing

### DIFF
--- a/.github/requirements-molecule.txt
+++ b/.github/requirements-molecule.txt
@@ -1,3 +1,3 @@
 ansible
 molecule
-molecule-plugins
+molecule-plugins[docker]

--- a/roles/postfix_ses/handlers/main.yml
+++ b/roles/postfix_ses/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Validate Postfix configuration
+  ansible.builtin.command:
+    cmd: postfix check
+  changed_when: false
+
+- name: Restart Postfix
+  ansible.builtin.service:
+    name: postfix
+    state: restarted
+  when: not postfix_ses_molecule | default(false)

--- a/roles/postfix_ses/molecule/default/converge.yml
+++ b/roles/postfix_ses/molecule/default/converge.yml
@@ -1,0 +1,14 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  gather_facts: true
+
+  vars:
+    postfix_ses_molecule: true
+    aws_ses_access_key_id: "MOLECULE_TEST_ACCESS_KEY" # pragma: allowlist secret
+    aws_ses_secret_access_key: "MOLECULE_TEST_SECRET_KEY" # pragma: allowlist secret
+    aws_ses_default_region: "eu-west-1"
+
+  roles:
+    - role: postfix_ses

--- a/roles/postfix_ses/molecule/default/molecule.yml
+++ b/roles/postfix_ses/molecule/default/molecule.yml
@@ -1,0 +1,35 @@
+---
+driver:
+  name: docker
+
+platforms:
+  - name: instance
+    image: geerlingguy/docker-ubuntu2404-ansible
+    pre_build_image: true
+    groups:
+      - default_hosts
+
+  - name: mailserver
+    image: geerlingguy/docker-ubuntu2204-ansible
+    pre_build_image: true
+    groups:
+      - mailservers
+
+provisioner:
+  name: ansible
+  env:
+    ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/.."
+    ANSIBLE_REMOTE_TMP: /tmp/.ansible/tmp
+
+scenario:
+  test_sequence:
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - destroy
+
+verifier:
+  name: ansible

--- a/roles/postfix_ses/molecule/default/prepare.yml
+++ b/roles/postfix_ses/molecule/default/prepare.yml
@@ -1,0 +1,40 @@
+---
+- name: Prepare
+  hosts: all
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Set predictable hostname
+      ansible.builtin.hostname:
+        name: "{{ inventory_hostname }}.test"
+
+    - name: Ensure /etc/mailname exists
+      ansible.builtin.copy:
+        content: "{{ inventory_hostname }}.test\n"
+        dest: /etc/mailname
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Configure Postfix debconf
+      ansible.builtin.debconf:
+        name: postfix
+        question: "{{ item.question }}"
+        value: "{{ item.value }}"
+        vtype: "{{ item.vtype }}"
+      loop:
+        - question: postfix/main_mailer_type
+          value: "Internet Site"
+          vtype: select
+        - question: postfix/mailname
+          value: "{{ 'amedee.be' if 'mailservers' in group_names else 'instance' }}"
+          vtype: string
+
+    - name: Install Postfix for testing
+      ansible.builtin.apt:
+        name:
+          - postfix
+          - postfix-pcre
+        state: present
+        update_cache: true

--- a/roles/postfix_ses/molecule/default/verify.yml
+++ b/roles/postfix_ses/molecule/default/verify.yml
@@ -1,0 +1,98 @@
+---
+- name: Verify normal server behavior
+  hosts: instance
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Verify Postfix configuration
+      ansible.builtin.command:
+        cmd: postfix check
+      changed_when: false
+
+    - name: Verify external mail uses SES transport
+      ansible.builtin.command:
+        cmd: postmap -q recipient@example.com pcre:/etc/postfix/transport.pcre
+      register: postfix_ses_external_transport_lookup
+      changed_when: false
+
+    - name: Assert external mail uses SES
+      ansible.builtin.assert:
+        that:
+          - postfix_ses_external_transport_lookup.stdout == "ses:"
+        fail_msg: >-
+          External mail is not routed through SES.
+          Result:
+          {{ postfix_ses_external_transport_lookup.stdout | default('(empty)') }}
+
+    - name: Verify amedee.be uses SES on non-mailservers
+      ansible.builtin.command:
+        cmd: postmap -q user@amedee.be pcre:/etc/postfix/transport.pcre
+      register: postfix_ses_amedee_transport_lookup
+      changed_when: false
+
+    - name: Assert amedee.be uses SES on non-mailservers
+      ansible.builtin.assert:
+        that:
+          - postfix_ses_amedee_transport_lookup.stdout == "ses:"
+        fail_msg: >-
+          amedee.be unexpectedly treated as local.
+          Result:
+          {{ postfix_ses_amedee_transport_lookup.stdout | default('(empty)') }}
+
+
+- name: Verify Mail-in-a-Box server behavior
+  hosts: mailserver
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Verify Postfix configuration
+      ansible.builtin.command:
+        cmd: postfix check
+      changed_when: false
+
+    - name: Verify external mail uses SES transport
+      ansible.builtin.command:
+        cmd: postmap -q recipient@example.com pcre:/etc/postfix/transport.pcre
+      register: postfix_ses_external_transport_lookup
+      changed_when: false
+
+    - name: Assert external mail uses SES
+      ansible.builtin.assert:
+        that:
+          - postfix_ses_external_transport_lookup.stdout == "ses:"
+        fail_msg: >-
+          External mail is not routed through SES.
+          Result:
+          {{ postfix_ses_external_transport_lookup.stdout | default('(empty)') }}
+
+    - name: Verify amedee.be stays local on mailservers
+      ansible.builtin.command:
+        cmd: postmap -q user@amedee.be pcre:/etc/postfix/transport.pcre
+      register: postfix_ses_amedee_transport_lookup
+      changed_when: false
+
+    - name: Assert amedee.be bypasses SES on mailservers
+      ansible.builtin.assert:
+        that:
+          - postfix_ses_amedee_transport_lookup.stdout != "ses:"
+        fail_msg: >-
+          amedee.be is incorrectly routed through SES.
+          Result:
+          {{ postfix_ses_amedee_transport_lookup.stdout | default('(empty)') }}
+
+    - name: Verify localhost address stays local
+      ansible.builtin.command:
+        cmd: postmap -q root@localhost pcre:/etc/postfix/transport.pcre
+      register: postfix_ses_localhost_transport_lookup
+      changed_when: false
+
+    - name: Assert localhost bypasses SES
+      ansible.builtin.assert:
+        that:
+          - postfix_ses_localhost_transport_lookup.stdout != "ses:"
+        fail_msg: >-
+          root@localhost is incorrectly routed through SES.
+          Result:
+          {{ postfix_ses_localhost_transport_lookup.stdout | default('(empty)') }}

--- a/roles/postfix_ses/tasks/main.yml
+++ b/roles/postfix_ses/tasks/main.yml
@@ -1,16 +1,52 @@
 ---
-- name: Install SES runtime dependencies
+- name: Install deb822 repository dependency
+  ansible.builtin.apt:
+    name:
+      - python3-debian
+    state: present
+    update_cache: true
+
+- name: Enable Ubuntu Universe repository
+  ansible.builtin.deb822_repository:
+    name: ubuntu-universe
+    types:
+      - deb
+    uris:
+      - "http://archive.ubuntu.com/ubuntu"
+    suites:
+      - "{{ ansible_distribution_release }}"
+    components:
+      - main
+      - universe
+      - restricted
+      - multiverse
+    state: present
+    enabled: true
+
+- name: Install SES wrapper dependencies
   ansible.builtin.apt:
     name:
       - python3-boto3
       - python3-botocore
+    state: present
+    update_cache: true
+
+- name: Verify Postfix configuration exists
+  ansible.builtin.stat:
+    path: /etc/postfix/main.cf
+  register: postfix_ses_main_cf
+
+- name: Require configured Postfix installation
+  ansible.builtin.assert:
+    that:
+      - postfix_ses_main_cf.stat.exists
+    fail_msg: "Postfix must be installed and configured before applying postfix_ses"
 
 - name: Ensure Postfix transport_maps is configured for SES
   ansible.builtin.lineinfile:
     path: /etc/postfix/main.cf
     regexp: '^transport_maps\s*='
     line: 'transport_maps = pcre:/etc/postfix/transport.pcre'
-    validate: 'postfix check'
   notify: Restart Postfix
 
 - name: Ensure SES transport exists
@@ -21,7 +57,6 @@
     block: |
       ses       unix  -       n       n       -       -       pipe
         flags=Rq user=ses argv=/usr/local/bin/ses_wrapper.sh ${recipient}
-    validate: "postfix check"
   notify: Restart Postfix
 
 - name: Ensure SES system user exists

--- a/roles/postfix_ses/templates/transport.pcre.j2
+++ b/roles/postfix_ses/templates/transport.pcre.j2
@@ -1,9 +1,12 @@
 # Local domains handled by Postfix as usual
-/^localhost$/       :
+
+/^localhost$/             :
+/^.*@localhost$/          :*
+
 {% if inventory_hostname in groups['mailservers'] %}
-/^.*@vangasse\.eu$/    :
-/^.*@.*\.vangasse\.eu$/     :
-/^.*@amedee\.be$/      :
+/^.*@vangasse\.eu$/       :
+/^.*@.*\.vangasse\.eu$/   :
+/^.*@amedee\.be$/         :
 {% endif %}
 
-/.*/                ses:
+/.*/                      ses:


### PR DESCRIPTION
- add Ubuntu 24.04 and 22.04 test platforms
- verify SES routing for external recipients
- verify local domain handling on mailservers
- verify localhost bypasses SES transport
