### PR TITLE
refactor: consolidate Molecule discovery and coverage

### DIFF
--- a/.github/scripts/molecule_coverage.py
+++ b/.github/scripts/molecule_coverage.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Discover Molecule scenarios and generate Molecule coverage information."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import subprocess
+
+COVERAGE_START = "<!-- molecule-coverage:start -->"
+COVERAGE_END = "<!-- molecule-coverage:end -->"
+
+
+def discover_roles() -> list[str]:
+    """Return all Ansible role names."""
+    roles_directory = pathlib.Path("roles")
+
+    return sorted(path.name for path in roles_directory.iterdir() if path.is_dir())
+
+
+def discover_scenarios() -> list[dict[str, str]]:
+    """Return all discovered Molecule scenarios."""
+    scenarios = []
+
+    for molecule_file in sorted(pathlib.Path("roles").glob("*/molecule/*/molecule.yml")):
+        scenario_directory = molecule_file.parent
+        role_directory = scenario_directory.parent.parent
+
+        scenarios.append(
+            {
+                "role": role_directory.name,
+                "scenario": scenario_directory.name,
+                "path": str(scenario_directory),
+            }
+        )
+
+    return scenarios
+
+
+def write_output(path: str, roles: list[str], scenarios: list[dict[str, str]]) -> None:
+    """Write discovery results to GITHUB_OUTPUT."""
+    with pathlib.Path(path).open("a", encoding="utf-8") as output:
+        output.write(f"roles={json.dumps(roles, separators=(',', ':'))}\n")
+        output.write(f"scenarios={json.dumps(scenarios, separators=(',', ':'))}\n")
+
+
+def write_discovery_summary(
+    path: str,
+    roles: list[str],
+    scenarios: list[dict[str, str]],
+) -> None:
+    """Write the discovery information to the GitHub step summary."""
+    repository_name = os.environ["GITHUB_REPOSITORY"]
+    sha = os.environ["GITHUB_SHA"]
+    server = os.environ["GITHUB_SERVER_URL"]
+
+    with pathlib.Path(path).open("a", encoding="utf-8") as summary:
+        summary.write("### Discovered roles\n\n")
+
+        for role in roles:
+            summary.write(f"- `{role}`\n")
+
+        summary.write("\n### Discovered scenarios\n\n")
+        summary.write("| Role | Scenario | Path |\n")
+        summary.write("| --- | --- | --- |\n")
+
+        for scenario in scenarios:
+            scenario_path = scenario["path"]
+            scenario_url = f"{server}/{repository_name}/tree/{sha}/{scenario_path}"
+
+            summary.write(
+                f"| `{scenario['role']}` | `{scenario['scenario']}` | [`{scenario_path}`]({scenario_url}) |\n"
+            )
+
+
+def calculate_coverage(
+    roles: list[str],
+    scenarios: list[dict[str, str]],
+) -> tuple[int, int, int]:
+    """Return covered roles, total roles and percentage."""
+    covered_roles = {scenario["role"] for scenario in scenarios}
+    tested = len(covered_roles)
+    total = len(roles)
+
+    percentage = round(tested * 100 / total) if total else 0
+
+    return tested, total, percentage
+
+
+def coverage_color(percentage: int) -> str:
+    """Return the shields.io color for a coverage percentage."""
+    if percentage >= 90:
+        return "brightgreen"
+
+    if percentage >= 75:
+        return "green"
+
+    if percentage >= 50:
+        return "yellow"
+
+    if percentage >= 25:
+        return "orange"
+
+    return "red"
+
+
+def render_coverage(
+    roles: list[str],
+    scenarios: list[dict[str, str]],
+) -> str:
+    """Render the Molecule coverage section."""
+    covered_roles = {scenario["role"] for scenario in scenarios}
+
+    lines = [
+        COVERAGE_START,
+        "",
+        "| Role | Molecule |",
+        "| --- | :---: |",
+    ]
+
+    for role in roles:
+        role_url = f"https://github.com/{repository()}/tree/main/roles/{role}"
+
+        molecule = "✅" if role in covered_roles else "❌"
+        lines.append(f"| [`{role}`]({role_url}) | {molecule} |")
+
+    lines.extend(
+        [
+            "",
+            COVERAGE_END,
+        ]
+    )
+
+    return "\n".join(lines)
+
+
+def repository() -> str:
+    """Return the current GitHub repository."""
+    result = subprocess.run(
+        ["git", "config", "--get", "remote.origin.url"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    remote = result.stdout.strip()
+
+    if remote.endswith(".git"):
+        remote = remote[:-4]
+
+    if remote.startswith("git@github.com:"):
+        return remote.removeprefix("git@github.com:")
+
+    return remote.removeprefix("https://github.com/")
+
+
+def update_readme(path: str, coverage: str) -> None:
+    """Replace or append the Molecule coverage section."""
+    readme_path = pathlib.Path(path)
+    contents = readme_path.read_text(encoding="utf-8")
+
+    start = contents.find(COVERAGE_START)
+    end = contents.find(COVERAGE_END)
+
+    if 0 <= start <= end and end >= 0:
+        end += len(COVERAGE_END)
+        contents = contents[:start] + coverage + contents[end:]
+    else:
+        separator = "" if contents.endswith("\n\n") else "\n\n"
+        contents = contents.rstrip() + separator + coverage + "\n"
+
+    readme_path.write_text(contents, encoding="utf-8")
+
+
+def write_badge(
+    directory: str,
+    tested: int,
+    total: int,
+    percentage: int,
+) -> None:
+    """Generate the Shields-compatible badge JSON."""
+    badge_directory = pathlib.Path(directory)
+    badge_directory.mkdir(parents=True, exist_ok=True)
+
+    badge = {
+        "schemaVersion": 1,
+        "label": "Molecule",
+        "message": f"{tested}/{total} roles ({percentage}%)",
+        "color": coverage_color(percentage),
+    }
+
+    (badge_directory / "molecule-coverage.json").write_text(
+        json.dumps(badge, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def write_coverage_summary(path: str, coverage: str) -> None:
+    """Write the coverage section to the GitHub step summary."""
+    with pathlib.Path(path).open("a", encoding="utf-8") as summary:
+        summary.write(coverage)
+        summary.write("\n")
+
+
+def discover_command(args: argparse.Namespace) -> None:
+    """Handle the discovery command."""
+    roles = discover_roles()
+    scenarios = discover_scenarios()
+
+    write_output(args.roles_output, roles, scenarios)
+    write_discovery_summary(args.summary_output, roles, scenarios)
+
+
+def coverage_command(args: argparse.Namespace) -> None:
+    """Handle the coverage command."""
+    roles: list[str] = json.loads(args.roles)
+    scenarios: list[dict[str, str]] = json.loads(args.scenarios)
+
+    tested, total, percentage = calculate_coverage(roles, scenarios)
+    coverage = render_coverage(roles, scenarios)
+
+    update_readme(args.readme, coverage)
+    write_badge(args.badge_directory, tested, total, percentage)
+    write_coverage_summary(args.summary_output, coverage)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(description="Discover Molecule scenarios and calculate coverage.")
+
+    subparsers = parser.add_subparsers(required=True)
+
+    discover = subparsers.add_parser("discover")
+    discover.add_argument("--roles-output", required=True)
+    discover.add_argument("--summary-output", required=True)
+    discover.set_defaults(func=discover_command)
+
+    coverage = subparsers.add_parser("coverage")
+    coverage.add_argument("--roles", required=True)
+    coverage.add_argument("--scenarios", required=True)
+    coverage.add_argument("--readme", required=True)
+    coverage.add_argument("--badge-directory", required=True)
+    coverage.add_argument("--summary-output", required=True)
+    coverage.set_defaults(func=coverage_command)
+
+    return parser
+
+
+def main() -> None:
+    """Run the command-line interface."""
+    args = build_parser().parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/molecule-coverage.yml
+++ b/.github/workflows/molecule-coverage.yml
@@ -3,6 +3,8 @@ name: 🧪 Molecule Coverage
 
 on: # yamllint disable-line rule:truthy
   push:
+    branches:
+      - main
     paths:
       - 'roles/**'
       - '.github/workflows/molecule-coverage.yml'

--- a/.github/workflows/molecule-coverage.yml
+++ b/.github/workflows/molecule-coverage.yml
@@ -6,18 +6,29 @@ on: # yamllint disable-line rule:truthy
     branches:
       - main
     paths:
-      - 'roles/**'
+      - 'roles/**/molecule/**'
+      - '.github/scripts/molecule_coverage.py'
+      - '.github/workflows/molecule.yml'
       - '.github/workflows/molecule-coverage.yml'
-      - "!**/*.md"
+      - 'README.md'
+      - "!roles/**/*.md"
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  molecule-coverage:
+  discover:
+    name: 🔍 Discover Molecule scenarios
+    uses: ./.github/workflows/molecule-discover.yml
+
+  coverage:
     name: Calculate Molecule coverage
+    needs: discover
     runs-on: ubuntu-slim
+
+    permissions:
+      contents: write
 
     steps:
       - name: Collect Workflow Telemetry
@@ -29,55 +40,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: false
+          persist-credentials: true
 
-      - name: Calculate coverage
-        id: coverage
-        shell: bash
-        run: |
-          total=$(find roles -mindepth 1 -maxdepth 1 -type d | wc -l)
-
-          tested=$(find roles -mindepth 2 -maxdepth 3 \
-            -type d \
-            -path '*/molecule/default' | wc -l)
-
-          percentage=$((tested * 100 / total))
-
-          if (( percentage >= 90 )); then
-            color=brightgreen
-          elif (( percentage >= 75 )); then
-            color=green
-          elif (( percentage >= 50 )); then
-            color=yellow
-          elif (( percentage >= 25 )); then
-            color=orange
-          else
-            color=red
-          fi
-
-          {
-            echo "total=$total"
-            echo "tested=$tested"
-            echo "percentage=$percentage"
-            echo "color=$color"
-            echo "message=${tested}/${total} roles (${percentage}%)"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Generate badge JSON
-        run: |
-          mkdir -p badge
-
-          cat > badge/molecule-coverage.json <<EOF
-          {
-            "schemaVersion": 1,
-            "label": "Molecule",
-            "message": "${STEPS_COVERAGE_OUTPUTS_MESSAGE}",
-            "color": "${STEPS_COVERAGE_OUTPUTS_COLOR}"
-          }
-          EOF
+      - name: Generate coverage
         env:
-          STEPS_COVERAGE_OUTPUTS_MESSAGE: ${{ steps.coverage.outputs.message }}
-          STEPS_COVERAGE_OUTPUTS_COLOR: ${{ steps.coverage.outputs.color }}
+          ROLES: ${{ needs.discover.outputs.roles }}
+          SCENARIOS: ${{ needs.discover.outputs.scenarios }}
+        run: |
+          python3 .github/scripts/molecule_coverage.py coverage \
+            --roles "${ROLES}" \
+            --scenarios "${SCENARIOS}" \
+            --readme README.md \
+            --badge-directory badge \
+            --summary-output "${GITHUB_STEP_SUMMARY}"
 
       - name: Publish badge
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
@@ -86,3 +61,17 @@ jobs:
           publish_branch: badges
           publish_dir: badge
           force_orphan: true
+
+      - name: Commit README changes
+        run: |
+          if git diff --quiet -- README.md; then
+            echo "README.md is already up to date."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add README.md
+          git commit -m "docs: update Molecule coverage"
+          git push

--- a/.github/workflows/molecule-discover.yml
+++ b/.github/workflows/molecule-discover.yml
@@ -1,0 +1,43 @@
+---
+name: 🧪 Molecule Discovery
+
+on: # yamllint disable-line rule:truthy
+  workflow_call:
+    outputs:
+      roles:
+        description: All Ansible roles in the repository
+        value: ${{ jobs.discover.outputs.roles }}
+      scenarios:
+        description: All discovered Molecule scenarios
+        value: ${{ jobs.discover.outputs.scenarios }}
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    name: 🔍 Discover scenarios
+    runs-on: ubuntu-slim
+
+    outputs:
+      roles: ${{ steps.discover.outputs.roles }}
+      scenarios: ${{ steps.discover.outputs.scenarios }}
+
+    steps:
+      - name: Collect Workflow Telemetry
+        # yamllint disable-line rule:line-length
+        uses: tsviz/actions-runner-telemetry@0fbec1ca185a193c94e4540e244110fdee912693 # v1.7.3
+        with:
+          enabled: ${{ vars.RUNNER_TELEMETRY_ENABLED || 'true' }}
+
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Discover roles and scenarios
+        id: discover
+        run: |
+          python3 .github/scripts/molecule_coverage.py discover \
+            --roles-output "${GITHUB_OUTPUT}" \
+            --summary-output "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -23,11 +23,12 @@ permissions:
 
 jobs:
   discover:
-    name: Discover Molecule scenarios
+    name: 🔍 Discover scenarios
 
     runs-on: ubuntu-slim
 
     outputs:
+      roles: ${{ steps.discover.outputs.roles }}
       scenarios: ${{ steps.discover.outputs.scenarios }}
 
     steps:
@@ -45,19 +46,85 @@ jobs:
       - name: Discover scenarios
         id: discover
         run: |
-          scenarios=$(
-            find roles -type f -path "*/molecule/*/molecule.yml" \
-            | sed 's#/molecule.yml##' \
-            | jq -R -s -c 'split("\n")[:-1]'
+          roles=$(
+            find roles \
+              -mindepth 1 \
+              -maxdepth 1 \
+              -type d \
+              -printf '%f\n' \
+              | sort \
+              | jq -R -s -c 'split("\n")[:-1]'
           )
 
+          scenarios=$(
+            find roles \
+              -type f \
+              -path "*/molecule/*/molecule.yml" \
+              | while IFS= read -r molecule_file; do
+                  scenario_dir="$(dirname "${molecule_file}")"
+                  role_dir="$(dirname "$(dirname "${scenario_dir}")")"
+
+                  jq -n \
+                    --arg role "$(basename "${role_dir}")" \
+                    --arg scenario "$(basename "${scenario_dir}")" \
+                    --arg path "${scenario_dir}" \
+                    '{
+                      role: $role,
+                      scenario: $scenario,
+                      path: $path
+                    }'
+                done \
+              | jq -s -c .
+          )
+
+          echo "roles=${roles}" >> "${GITHUB_OUTPUT}"
           echo "scenarios=${scenarios}" >> "${GITHUB_OUTPUT}"
+
+          echo "Discovered roles:"
+          echo "${roles}" | jq .
 
           echo "Discovered scenarios:"
           echo "${scenarios}" | jq .
 
+      - name: Generate Molecule coverage summary
+        run: |
+          covered_roles=$(
+            printf '%s\n' "${STEPS_DISCOVER_OUTPUTS_SCENARIOS}" \
+              | jq '[.[].role] | unique | length'
+          )
+
+          total_roles=$(
+            printf '%s\n' "${STEPS_DISCOVER_OUTPUTS_ROLES}" \
+              | jq 'length'
+          )
+
+          {
+            echo "## Molecule Coverage (${covered_roles}/${total_roles})"
+            echo
+            echo "| Role | Molecule |"
+            echo "| --- | :---: |"
+
+            printf '%s\n' "${STEPS_DISCOVER_OUTPUTS_ROLES}" \
+              | jq -r '.[]' \
+              | while IFS= read -r role; do
+                role_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${GITHUB_SHA}/roles/${role}"
+
+                if printf '%s\n' "${STEPS_DISCOVER_OUTPUTS_SCENARIOS}" \
+                  | jq -e --arg role "${role}" \
+                  'any(.[]; .role == $role)' \
+                  > /dev/null; then
+                  echo "| [\`${role}\`](${role_url}) | ✅ |"
+                else
+                  echo "| [\`${role}\`](${role_url}) | ❌ |"
+                fi
+              done
+          } >> "${GITHUB_STEP_SUMMARY}"
+        env:
+          STEPS_DISCOVER_OUTPUTS_SCENARIOS: ${{ steps.discover.outputs.scenarios }}
+          STEPS_DISCOVER_OUTPUTS_ROLES: ${{ steps.discover.outputs.roles }}
+
   molecule:
-    name: Molecule (${{ matrix.scenario }})
+    name: ${{ matrix.scenario.role }}-${{ matrix.scenario.scenario }}
     needs: discover
 
     runs-on: ubuntu-latest
@@ -90,13 +157,11 @@ jobs:
 
       - name: Run Molecule
         run: |
-          role_dir="$(dirname "$(dirname "${MATRIX_SCENARIO}")")"
-          scenario_name="$(basename "${MATRIX_SCENARIO}")"
+          echo "Role: ${MATRIX_ROLE}"
+          echo "Scenario: ${MATRIX_SCENARIO}"
 
-          echo "Role directory: ${role_dir}"
-          echo "Scenario: ${scenario_name}"
-
-          cd "${role_dir}"
-          molecule test -s "${scenario_name}"
+          cd "roles/${MATRIX_ROLE}"
+          molecule test -s "${MATRIX_SCENARIO}"
         env:
-          MATRIX_SCENARIO: ${{ matrix.scenario }}
+          MATRIX_ROLE: ${{ matrix.scenario.role }}
+          MATRIX_SCENARIO: ${{ matrix.scenario.scenario }}

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -24,104 +24,7 @@ permissions:
 jobs:
   discover:
     name: 🔍 Discover scenarios
-
-    runs-on: ubuntu-slim
-
-    outputs:
-      roles: ${{ steps.discover.outputs.roles }}
-      scenarios: ${{ steps.discover.outputs.scenarios }}
-
-    steps:
-      - name: Collect Workflow Telemetry
-        # yamllint disable-line rule:line-length
-        uses: tsviz/actions-runner-telemetry@0fbec1ca185a193c94e4540e244110fdee912693 # v1.7.3
-        with:
-          enabled: ${{ vars.RUNNER_TELEMETRY_ENABLED || 'true' }}
-
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Discover scenarios
-        id: discover
-        run: |
-          roles=$(
-            find roles \
-              -mindepth 1 \
-              -maxdepth 1 \
-              -type d \
-              -printf '%f\n' \
-              | sort \
-              | jq -R -s -c 'split("\n")[:-1]'
-          )
-
-          scenarios=$(
-            find roles \
-              -type f \
-              -path "*/molecule/*/molecule.yml" \
-              | while IFS= read -r molecule_file; do
-                  scenario_dir="$(dirname "${molecule_file}")"
-                  role_dir="$(dirname "$(dirname "${scenario_dir}")")"
-
-                  jq -n \
-                    --arg role "$(basename "${role_dir}")" \
-                    --arg scenario "$(basename "${scenario_dir}")" \
-                    --arg path "${scenario_dir}" \
-                    '{
-                      role: $role,
-                      scenario: $scenario,
-                      path: $path
-                    }'
-                done \
-              | jq -s -c .
-          )
-
-          echo "roles=${roles}" >> "${GITHUB_OUTPUT}"
-          echo "scenarios=${scenarios}" >> "${GITHUB_OUTPUT}"
-
-          echo "Discovered roles:"
-          echo "${roles}" | jq .
-
-          echo "Discovered scenarios:"
-          echo "${scenarios}" | jq .
-
-      - name: Generate Molecule coverage summary
-        run: |
-          covered_roles=$(
-            printf '%s\n' "${STEPS_DISCOVER_OUTPUTS_SCENARIOS}" \
-              | jq '[.[].role] | unique | length'
-          )
-
-          total_roles=$(
-            printf '%s\n' "${STEPS_DISCOVER_OUTPUTS_ROLES}" \
-              | jq 'length'
-          )
-
-          {
-            echo "## Molecule Coverage (${covered_roles}/${total_roles})"
-            echo
-            echo "| Role | Molecule |"
-            echo "| --- | :---: |"
-
-            printf '%s\n' "${STEPS_DISCOVER_OUTPUTS_ROLES}" \
-              | jq -r '.[]' \
-              | while IFS= read -r role; do
-                role_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${GITHUB_SHA}/roles/${role}"
-
-                if printf '%s\n' "${STEPS_DISCOVER_OUTPUTS_SCENARIOS}" \
-                  | jq -e --arg role "${role}" \
-                  'any(.[]; .role == $role)' \
-                  > /dev/null; then
-                  echo "| [\`${role}\`](${role_url}) | ✅ |"
-                else
-                  echo "| [\`${role}\`](${role_url}) | ❌ |"
-                fi
-              done
-          } >> "${GITHUB_STEP_SUMMARY}"
-        env:
-          STEPS_DISCOVER_OUTPUTS_SCENARIOS: ${{ steps.discover.outputs.scenarios }}
-          STEPS_DISCOVER_OUTPUTS_ROLES: ${{ steps.discover.outputs.roles }}
+    uses: ./.github/workflows/molecule-discover.yml
 
   molecule:
     name: ${{ matrix.scenario.role }}-${{ matrix.scenario.scenario }}
@@ -156,12 +59,7 @@ jobs:
         uses: ./.github/actions/restore-ansible-cache
 
       - name: Run Molecule
-        run: |
-          echo "Role: ${MATRIX_ROLE}"
-          echo "Scenario: ${MATRIX_SCENARIO}"
-
-          cd "roles/${MATRIX_ROLE}"
-          molecule test -s "${MATRIX_SCENARIO}"
+        run: molecule test -s "${MATRIX_SCENARIO}"
+        working-directory: roles/${{ matrix.scenario.role }}
         env:
-          MATRIX_ROLE: ${{ matrix.scenario.role }}
           MATRIX_SCENARIO: ${{ matrix.scenario.scenario }}

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ This repository uses CI to continuously validate configuration quality:
 
 [![Molecule Coverage][molecule-badge]][molecule-status]
 
+<!-- molecule-coverage:start -->
+
+<!-- Molecule coverage is generated automatically. -->
+
+<!-- molecule-coverage:end -->
+
 [![Deployment Status][deployment-badge]][deployment-status]
 [![Codacy Badge][codacy-badge]][codacy-grade]
 [![Super-Linter][superlinter-badge]][superlinter-status]


### PR DESCRIPTION
Reuse Molecule scenario discovery for testing and coverage, and move
coverage generation into a dedicated script. Update the root README with
the calculated role coverage and keep the coverage badge in sync.