### PR TITLE
⬆️ Pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     hooks:
       - id: blocklint
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.4
+    rev: 0.38.0
     hooks:
       - id: check-github-actions
         args: [--verbose]


### PR DESCRIPTION
🔧 Bump check-jsonschema to 0.38.0 for fresher GitHub Actions linting

Updated the check-jsonschema hook from 0.37.4 to 0.38.0 to snag the latest schema validation goodies
Your GitHub Actions workflows will thank you for the stricter checks and shinier error messages