### PR TITLE
📚️ Update Ansible role docs

### DIFF
--- a/roles/postfix/README.md
+++ b/roles/postfix/README.md
@@ -5,6 +5,9 @@ Role to configure Postfix.
 ## Table of contents
 
 - [Requirements](#requirements)
+- [Default Variables](#default-variables)
+  - [postfix_invalid_recipients](#postfix_invalid_recipients)
+  - [postfix_mydomains](#postfix_mydomains)
 - [Dependencies](#dependencies)
 - [License](#license)
 - [Author](#author)
@@ -14,6 +17,24 @@ Role to configure Postfix.
 ## Requirements
 
 - Minimum Ansible version: `2.1`
+
+## Default Variables
+
+### postfix_invalid_recipients
+
+#### Default value
+
+```YAML
+postfix_invalid_recipients: []
+```
+
+### postfix_mydomains
+
+#### Default value
+
+```YAML
+postfix_mydomains: []
+```
 
 ## Dependencies
 


### PR DESCRIPTION
📝 Document new Postfix default variables for recipient and domain confi

Added docs for postfix_invalid_recipients and postfix_mydomains so you
actually know what these empty arrays do instead of guessing like a detective.
No more mystery meat configuration — just clean defaults ready for your
customization. You're welcome, future me!