### PR TITLE
⬆️ Update Ansible requirements

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -11,7 +11,7 @@ collections:
   - name: ansible.utils
     version: 6.0.3
   - name: community.docker
-    version: 5.2.1
+    version: 5.2.2
   - name: community.general
     version: 13.2.0
   - name: ansible.mysql


### PR DESCRIPTION
🐳 Bump community.docker to 5.2.2 for fresh container vibes

Updated the community.docker collection from 5.2.1 to 5.2.2 in requirements.yml
This patch release brings bug fixes and improvements for Docker modules
Keeping dependencies current because stale collections are so last season